### PR TITLE
perf: tighten benchmark harness overhead

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -5,8 +5,8 @@ This page documents the current `rudp_bench` smoke benchmark and keeps a small r
 ## What `rudp_bench` measures
 
 - In-memory endpoint-to-endpoint transfer with no real socket I/O.
-- Fixed payload size: `96` bytes.
-- Fixed message count: `20000`.
+- Default payload size: `96` bytes; override with `rudp_bench <messages> <payload_bytes>`.
+- Default message count: `20000`; override with `rudp_bench <messages> <payload_bytes>`.
 - Auth enabled.
 - Mid-run key rotation enabled.
 - Alternating `Send()` and `SendZeroCopy()` calls.
@@ -24,6 +24,8 @@ The benchmark is useful for regression tracking inside the protocol core. It is 
 cmake -S . -B build
 cmake --build build --config Release
 build/rudp_bench
+# longer local profiling run:
+build/rudp_bench 2000000 96
 ```
 
 ## Recording Rules
@@ -43,10 +45,12 @@ Only compare samples that keep the same benchmark shape from `tests/bench.cpp`.
 | Release | Date | Platform | Build | Sample Output |
 |---------|------|----------|-------|---------------|
 | `v0.1.2` | `2026-03-28` | Windows local dev machine | `Release` | `rudp bench: messages=20000 payload=96B time=0.033s msg/s=606060.6 MB/s=55.49` |
+| `master` | `2026-03-30` | Windows local dev machine | `Release` | `rudp bench: messages=20000 payload=96B time=0.028s msg/s=714285.7 MB/s=65.39` |
 
 ## Current Sample Notes
 
-- The `v0.1.2` sample is a local Windows run, not a cross-platform median.
+- The `v0.1.2` and `master` samples are local Windows runs, not cross-platform medians.
+- The `2026-03-30` `master` sample is not directly comparable to older archive lines unless you account for the benchmark harness cleanup that removed avoidable packet copies inside `tests/bench.cpp`.
 - CI currently verifies that `rudp_bench` runs, but does not archive performance outputs automatically.
 - Future entries should stay conservative and avoid mixing unlike environments.
 

--- a/include/rudp/rudp.hpp
+++ b/include/rudp/rudp.hpp
@@ -205,7 +205,7 @@ private:
     uint16_t DistanceFrom(uint16_t older, uint16_t newer) const;
     PacketSlot* FindSendSlotBySeq(uint16_t seq);
     RecvSlot* FindRecvSlotBySeq(uint16_t seq);
-    PacketSlot* AllocateSendSlot();
+    PacketSlot* AllocateSendSlot(uint16_t* inflight_count);
     RecvSlot* AllocateRecvSlot();
     void MaybeAdjustRto(uint32_t sample_ms);
 

--- a/src/rudp.cpp
+++ b/src/rudp.cpp
@@ -511,22 +511,25 @@ bool Endpoint::SeqInWindow(uint16_t seq, uint16_t start, uint16_t window) const 
     return DistanceFrom(start, seq) < window;
 }
 
-Endpoint::PacketSlot* Endpoint::AllocateSendSlot() {
+Endpoint::PacketSlot* Endpoint::AllocateSendSlot(uint16_t* inflight_count) {
+    PacketSlot* free_slot = 0;
+    uint16_t inflight = 0;
     for (uint16_t i = 0; i < kMaxQueue; ++i) {
-        if (!send_slots_[i].used) {
-            send_slots_[i].used = true;
-            send_slots_[i].acked = false;
-            send_slots_[i].ever_sent = false;
-            send_slots_[i].zero_copy = false;
-            send_slots_[i].retries = 0;
-            send_slots_[i].payload_len = 0;
-            send_slots_[i].frame_len = 0;
-            send_slots_[i].last_sent_ms = 0;
-            send_slots_[i].ext_payload = 0;
-            return &send_slots_[i];
+        PacketSlot* slot = &send_slots_[i];
+        if (slot->used) {
+            if (!slot->acked) {
+                ++inflight;
+            }
+            continue;
+        }
+        if (!free_slot) {
+            free_slot = slot;
         }
     }
-    return 0;
+    if (inflight_count) {
+        *inflight_count = inflight;
+    }
+    return free_slot;
 }
 
 Endpoint::RecvSlot* Endpoint::AllocateRecvSlot() {
@@ -804,21 +807,26 @@ SendStatus Endpoint::Send(const uint8_t* payload, uint16_t len) {
     }
 
     uint16_t inflight = 0;
-    for (uint16_t i = 0; i < kMaxQueue; ++i) {
-        if (send_slots_[i].used && !send_slots_[i].acked) {
-            ++inflight;
-        }
-    }
+    PacketSlot* slot = AllocateSendSlot(&inflight);
     if (inflight >= cfg_.send_window) {
         Unlock();
         return SendStatus::kQueueFull;
     }
 
-    PacketSlot* slot = AllocateSendSlot();
     if (!slot) {
         Unlock();
         return SendStatus::kQueueFull;
     }
+
+    slot->used = true;
+    slot->acked = false;
+    slot->ever_sent = false;
+    slot->zero_copy = false;
+    slot->retries = 0;
+    slot->payload_len = 0;
+    slot->frame_len = 0;
+    slot->last_sent_ms = 0;
+    slot->ext_payload = 0;
 
     const uint16_t seq = next_send_seq_;
     ++next_send_seq_;
@@ -854,21 +862,26 @@ SendStatus Endpoint::SendZeroCopy(const uint8_t* payload, uint16_t len) {
     }
 
     uint16_t inflight = 0;
-    for (uint16_t i = 0; i < kMaxQueue; ++i) {
-        if (send_slots_[i].used && !send_slots_[i].acked) {
-            ++inflight;
-        }
-    }
+    PacketSlot* slot = AllocateSendSlot(&inflight);
     if (inflight >= cfg_.send_window) {
         Unlock();
         return SendStatus::kQueueFull;
     }
 
-    PacketSlot* slot = AllocateSendSlot();
     if (!slot) {
         Unlock();
         return SendStatus::kQueueFull;
     }
+
+    slot->used = true;
+    slot->acked = false;
+    slot->ever_sent = false;
+    slot->zero_copy = false;
+    slot->retries = 0;
+    slot->payload_len = 0;
+    slot->frame_len = 0;
+    slot->last_sent_ms = 0;
+    slot->ext_payload = 0;
 
     const uint16_t seq = next_send_seq_;
     ++next_send_seq_;

--- a/tests/bench.cpp
+++ b/tests/bench.cpp
@@ -1,6 +1,7 @@
 #include "rudp/rudp.hpp"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <vector>
@@ -16,32 +17,46 @@ static uint32_t BNow(void* u) {
     return static_cast<BenchWire*>(u)->now_ms;
 }
 
+static bool EnqueuePacket(std::vector<std::vector<uint8_t> >* queue, const uint8_t* d, uint16_t n) {
+    if (!queue || (!d && n > 0)) {
+        return false;
+    }
+    queue->push_back(std::vector<uint8_t>(d, d + n));
+    return true;
+}
+
+static bool EnqueuePacketVec(std::vector<std::vector<uint8_t> >* queue,
+                             const uint8_t* h, uint16_t hn,
+                             const uint8_t* b, uint16_t bn) {
+    if (!queue || (!h && hn > 0) || (!b && bn > 0)) {
+        return false;
+    }
+    std::vector<uint8_t> pkt;
+    pkt.reserve(static_cast<size_t>(hn) + static_cast<size_t>(bn));
+    pkt.insert(pkt.end(), h, h + hn);
+    pkt.insert(pkt.end(), b, b + bn);
+    queue->push_back(std::move(pkt));
+    return true;
+}
+
 static bool BSendA(void* u, const uint8_t* d, uint16_t n) {
     BenchWire* w = static_cast<BenchWire*>(u);
-    w->a2b.push_back(std::vector<uint8_t>(d, d + n));
-    return true;
+    return EnqueuePacket(&w->a2b, d, n);
 }
 
 static bool BSendB(void* u, const uint8_t* d, uint16_t n) {
     BenchWire* w = static_cast<BenchWire*>(u);
-    w->b2a.push_back(std::vector<uint8_t>(d, d + n));
-    return true;
+    return EnqueuePacket(&w->b2a, d, n);
 }
 
 static bool BSendAVec(void* u, const uint8_t* h, uint16_t hn, const uint8_t* b, uint16_t bn) {
-    std::vector<uint8_t> pkt;
-    pkt.reserve(static_cast<size_t>(hn) + static_cast<size_t>(bn));
-    pkt.insert(pkt.end(), h, h + hn);
-    pkt.insert(pkt.end(), b, b + bn);
-    return BSendA(u, &pkt[0], static_cast<uint16_t>(pkt.size()));
+    BenchWire* w = static_cast<BenchWire*>(u);
+    return EnqueuePacketVec(&w->a2b, h, hn, b, bn);
 }
 
 static bool BSendBVec(void* u, const uint8_t* h, uint16_t hn, const uint8_t* b, uint16_t bn) {
-    std::vector<uint8_t> pkt;
-    pkt.reserve(static_cast<size_t>(hn) + static_cast<size_t>(bn));
-    pkt.insert(pkt.end(), h, h + hn);
-    pkt.insert(pkt.end(), b, b + bn);
-    return BSendB(u, &pkt[0], static_cast<uint16_t>(pkt.size()));
+    BenchWire* w = static_cast<BenchWire*>(u);
+    return EnqueuePacketVec(&w->b2a, h, hn, b, bn);
 }
 
 static void BDeliverA(void*, const uint8_t*, uint16_t) {}
@@ -51,13 +66,46 @@ static void BDeliverB(void* u, const uint8_t*, uint16_t) {
     ++w->delivered;
 }
 
-int main() {
-    const uint32_t kMessages = 20000;
-    const uint16_t kPayloadSize = 96;
+static bool ParseU32Arg(const char* text, uint32_t* out) {
+    if (!text || !out || *text == '\0') {
+        return false;
+    }
+    char* end = 0;
+    const unsigned long value = strtoul(text, &end, 10);
+    if (*end != '\0') {
+        return false;
+    }
+    *out = static_cast<uint32_t>(value);
+    return true;
+}
+
+int main(int argc, char** argv) {
+    uint32_t messages = 20000;
+    uint32_t payload_size_u32 = 96;
+    if (argc >= 2 && !ParseU32Arg(argv[1], &messages)) {
+        fprintf(stderr, "usage: %s [messages] [payload_bytes]\n", argv[0]);
+        return 3;
+    }
+    if (argc >= 3 && !ParseU32Arg(argv[2], &payload_size_u32)) {
+        fprintf(stderr, "usage: %s [messages] [payload_bytes]\n", argv[0]);
+        return 3;
+    }
+    if (messages == 0) {
+        fputs("bench messages must be > 0\n", stderr);
+        return 3;
+    }
+    if (payload_size_u32 == 0 || payload_size_u32 > 120u) {
+        fputs("bench payload must be in range 1..120 bytes\n", stderr);
+        return 3;
+    }
+    const uint16_t payload_size = static_cast<uint16_t>(payload_size_u32);
 
     BenchWire wire;
     wire.now_ms = 1;
     wire.delivered = 0;
+
+    wire.a2b.reserve(64);
+    wire.b2a.reserve(64);
 
     rudp::Config cfg = rudp::DefaultConfig();
     cfg.mtu = 192;
@@ -88,12 +136,12 @@ int main() {
         a.Tick();
         b.Tick();
         while (!wire.a2b.empty()) {
-            std::vector<uint8_t> pkt = wire.a2b.back();
+            std::vector<uint8_t> pkt = std::move(wire.a2b.back());
             wire.a2b.pop_back();
             b.OnUdpPacket(&pkt[0], static_cast<uint16_t>(pkt.size()));
         }
         while (!wire.b2a.empty()) {
-            std::vector<uint8_t> pkt = wire.b2a.back();
+            std::vector<uint8_t> pkt = std::move(wire.b2a.back());
             wire.b2a.pop_back();
             a.OnUdpPacket(&pkt[0], static_cast<uint16_t>(pkt.size()));
         }
@@ -106,18 +154,17 @@ int main() {
         return 2;
     }
 
-    uint8_t payload[kPayloadSize];
-    memset(payload, 'x', sizeof(payload));
+    std::vector<uint8_t> payload(payload_size, static_cast<uint8_t>('x'));
 
     const clock_t t0 = clock();
     uint32_t sent = 0;
     bool rotated = false;
-    while (wire.delivered < kMessages) {
+    while (wire.delivered < messages) {
         ++wire.now_ms;
         a.Tick();
         b.Tick();
 
-        if (!rotated && sent >= (kMessages / 2u)) {
+        if (!rotated && sent >= (messages / 2u)) {
             a.SetAuthKey(2, 0x3132333435363738ull, 0x4142434445464748ull, false);
             b.SetAuthKey(2, 0x3132333435363738ull, 0x4142434445464748ull, false);
             a.ScheduleTxKeyRotation(2, 32);
@@ -125,10 +172,10 @@ int main() {
             rotated = true;
         }
 
-        while (sent < kMessages) {
+        while (sent < messages) {
             rudp::SendStatus st = ((sent & 1u) == 0u)
-                                      ? a.Send(payload, kPayloadSize)
-                                      : a.SendZeroCopy(payload, kPayloadSize);
+                                      ? a.Send(payload.data(), payload_size)
+                                      : a.SendZeroCopy(payload.data(), payload_size);
             if (st != rudp::SendStatus::kOk) {
                 break;
             }
@@ -136,12 +183,12 @@ int main() {
         }
 
         while (!wire.a2b.empty()) {
-            std::vector<uint8_t> pkt = wire.a2b.back();
+            std::vector<uint8_t> pkt = std::move(wire.a2b.back());
             wire.a2b.pop_back();
             b.OnUdpPacket(&pkt[0], static_cast<uint16_t>(pkt.size()));
         }
         while (!wire.b2a.empty()) {
-            std::vector<uint8_t> pkt = wire.b2a.back();
+            std::vector<uint8_t> pkt = std::move(wire.b2a.back());
             wire.b2a.pop_back();
             a.OnUdpPacket(&pkt[0], static_cast<uint16_t>(pkt.size()));
         }
@@ -149,12 +196,12 @@ int main() {
     const clock_t t1 = clock();
 
     const double sec = static_cast<double>(t1 - t0) / static_cast<double>(CLOCKS_PER_SEC);
-    const double msgps = static_cast<double>(kMessages) / sec;
-    const double mbps = (static_cast<double>(kMessages) * static_cast<double>(kPayloadSize)) / (1024.0 * 1024.0) / sec;
+    const double msgps = static_cast<double>(messages) / sec;
+    const double mbps = (static_cast<double>(messages) * static_cast<double>(payload_size)) / (1024.0 * 1024.0) / sec;
 
     printf("rudp bench: messages=%u payload=%uB time=%.3fs msg/s=%.1f MB/s=%.2f\n",
-           static_cast<unsigned>(kMessages),
-           static_cast<unsigned>(kPayloadSize),
+           static_cast<unsigned>(messages),
+           static_cast<unsigned>(payload_size),
            sec, msgps, mbps);
     return 0;
 }


### PR DESCRIPTION
## Summary
- make udp_bench configurable so local profiling can run longer and collect stable CPU/memory samples
- remove avoidable packet copies inside the benchmark harness and reserve its local queues
- collapse the send-window check and free-slot search into a single scan in Endpoint::Send*`n- refresh benchmark docs with the new local profiling command and current Windows sample

## Testing
- cmake --build build --config Release --target rudp_bench rudp_self_test rudp_reliability_test rudp_manager_test rudp_c_api_test
- ctest --test-dir build -C Release --output-on-failure
- .\\build\\Release\\rudp_bench.exe
- .\\build\\Release\\rudp_bench.exe 1000000 32
- .\\build\\Release\\rudp_bench.exe 1000000 96
- .\\build\\Release\\rudp_bench.exe 1000000 120
- .\\build\\Release\\rudp_bench.exe 2000000 96
- long local sample: 5000000 messages, 96-byte payload; wall ~= 7.266s, cpu ~= 7.266s, peak working set ~= 3.934 MB, peak private ~= 0.762 MB

## Notes
- Most of the measurable gain comes from removing benchmark harness overhead, which makes the benchmark a better proxy for protocol-core regressions.
- The send-slot scan merge is intentionally small and low-risk; it improved throughput modestly after the harness cleanup.