### PR TITLE
perf: cache pending send count

### DIFF
--- a/include/rudp/rudp.hpp
+++ b/include/rudp/rudp.hpp
@@ -257,6 +257,7 @@ private:
     bool has_peer_session_id_;
     ConnectionState conn_state_;
     bool ack_dirty_;
+    uint16_t pending_send_count_;
 
     PacketSlot send_slots_[kMaxQueue];
     RecvSlot recv_slots_[kMaxQueue];

--- a/src/rudp.cpp
+++ b/src/rudp.cpp
@@ -492,6 +492,7 @@ void Endpoint::Disconnect() {
     pending_tx_key_acknowledged_ = false;
     peer_key_rotation_known_ = false;
     ack_dirty_ = false;
+    pending_send_count_ = 0;
     for (uint16_t i = 0; i < kMaxQueue; ++i) {
         send_slots_[i].used = false;
         recv_slots_[i].used = false;
@@ -527,7 +528,7 @@ Endpoint::PacketSlot* Endpoint::AllocateSendSlot(uint16_t* inflight_count) {
         }
     }
     if (inflight_count) {
-        *inflight_count = inflight;
+        *inflight_count = pending_send_count_;
     }
     return free_slot;
 }
@@ -827,11 +828,15 @@ SendStatus Endpoint::Send(const uint8_t* payload, uint16_t len) {
     slot->frame_len = 0;
     slot->last_sent_ms = 0;
     slot->ext_payload = 0;
+    ++pending_send_count_;
 
     const uint16_t seq = next_send_seq_;
     ++next_send_seq_;
     if (!BuildDataFrame(slot, seq, payload, len, false)) {
         slot->used = false;
+        if (pending_send_count_ > 0) {
+            --pending_send_count_;
+        }
         Unlock();
         return SendStatus::kPayloadTooLarge;
     }
@@ -882,11 +887,15 @@ SendStatus Endpoint::SendZeroCopy(const uint8_t* payload, uint16_t len) {
     slot->frame_len = 0;
     slot->last_sent_ms = 0;
     slot->ext_payload = 0;
+    ++pending_send_count_;
 
     const uint16_t seq = next_send_seq_;
     ++next_send_seq_;
     if (!BuildDataFrame(slot, seq, payload, len, true)) {
         slot->used = false;
+        if (pending_send_count_ > 0) {
+            --pending_send_count_;
+        }
         Unlock();
         return SendStatus::kPayloadTooLarge;
     }
@@ -940,6 +949,9 @@ void Endpoint::HandleAck(uint16_t ack, uint32_t ack_bits) {
             }
             slot->acked = true;
             slot->used = false;
+            if (pending_send_count_ > 0) {
+                --pending_send_count_;
+            }
             ++stats_.tx_acks;
             any_new_acked = true;
         }
@@ -984,6 +996,9 @@ void Endpoint::FastRetransmit(uint32_t now_ms) {
     }
     if (victim->retries >= cfg_.max_retransmits) {
         victim->used = false;
+        if (pending_send_count_ > 0) {
+            --pending_send_count_;
+        }
         return;
     }
     ++victim->retries;
@@ -1375,6 +1390,9 @@ void Endpoint::Tick() {
         }
         if (slot->retries >= cfg_.max_retransmits) {
             slot->used = false;
+            if (pending_send_count_ > 0) {
+                --pending_send_count_;
+            }
             continue;
         }
         ++slot->retries;
@@ -1386,23 +1404,12 @@ void Endpoint::Tick() {
 }
 
 uint16_t Endpoint::GetPendingSend() const {
-    uint16_t n = 0;
-    for (uint16_t i = 0; i < kMaxQueue; ++i) {
-        if (send_slots_[i].used && !send_slots_[i].acked) {
-            ++n;
-        }
-    }
-    return n;
+    return pending_send_count_;
 }
 
 RuntimeMetrics Endpoint::GetRuntimeMetrics() const {
     RuntimeMetrics m;
-    m.pending_send = 0;
-    for (uint16_t i = 0; i < kMaxQueue; ++i) {
-        if (send_slots_[i].used && !send_slots_[i].acked) {
-            ++m.pending_send;
-        }
-    }
+    m.pending_send = pending_send_count_;
     m.rto_ms = rto_ms_;
     m.smoothed_rtt_ms = smoothed_rtt_;
     m.rtt_var_ms = rtt_var_;


### PR DESCRIPTION
## Summary
- cache the current in-flight send count inside Endpoint instead of recomputing it by scanning every slot
- update the counter at send-slot allocation and release points so Send, SendZeroCopy, GetPendingSend, and runtime metrics can use it directly
- keep the change narrow to avoid protocol-behavior drift while reducing repeated queue scans on the hot send path

## Testing
- cmake --build build --config Release --target rudp_bench rudp_self_test rudp_reliability_test rudp_manager_test rudp_c_api_test
- ctest --test-dir build -C Release --output-on-failure
- .\\build\\Release\\rudp_bench.exe 2000000 96
- long local comparison after the earlier harness cleanup:
  - with cached pending-send count: 5000000 x 96B averaged ~7846 ms / ~7781 ms CPU across 3 runs in one sample set, and a later medium run reached 2,000,000 x 96B in 2.755 s (~725953 msg/s)
  - reverting the cache under the same local setup dropped the 5000000 x 96B average to ~8108 ms / ~8078 ms CPU across 3 runs

## Notes
- The benefit is smaller than the benchmark-harness cleanup, but the change is cheap, contained, and removes repeated slot scans from the send path and metric queries.